### PR TITLE
Adding GitHub Issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/non-technical-issue.yml
+++ b/.github/ISSUE_TEMPLATE/non-technical-issue.yml
@@ -1,0 +1,39 @@
+name: 📚 Non-Technical Issue
+description: Use this form to submit content suggestions, fixes, and questions as well as any other non-technical topic.
+title: "Non-Technical Issue:"
+
+body:
+- type: dropdown
+  id: issueLoc
+  attributes:
+    label: Issue Location
+    description: "Where is this issue located?"
+    options:
+      - javadocs
+      - README file
+      - Other
+  validations:
+    required: true
+- type: dropdown
+  id: issueTypeN
+  attributes:
+    label: "Issue Type"
+    description: "What type of issue is this?"
+    options:
+      - Content addition
+      - Content correction
+      - Question
+      - Typo, syntax, or other minor fixes
+      - Other
+- type: textarea
+  id: description
+  attributes:
+    label: "Issue Description"
+    description: "Use the area below to concisely describe the issue, including any necessary links to navigate to the issue location" 
+- type: checkboxes
+  id: selfhelp
+  attributes:
+    label: Self-Service
+    description: If you feel like you could contribute to this issue, please check the box below.
+    options:
+      - label: I would be willing to fix this issue

--- a/.github/ISSUE_TEMPLATE/techIssue.yml
+++ b/.github/ISSUE_TEMPLATE/techIssue.yml
@@ -1,0 +1,60 @@
+name: "💻 Technical Issue"
+description: Use this form to report any issue that will involve touching code within this repository
+title: "Technical Issue: "
+
+body:
+- type: dropdown
+  id: issueType
+  attributes:
+    label: Issue Type
+    description: Select the technical issue type that most closely aligns with the issue you wish to report
+    options:
+      - Bug
+      - Accessibility Issue
+      - Feature Request
+      - Other Technical Issue
+  validations:
+    required: true
+- type: textarea
+  id: expected
+  attributes:
+    label: "Expected Behavior"
+    description: "Clearly and concisely describe what you expect or propose to happen:"
+- type: textarea
+  id: current
+  attributes:
+    label: "Current Behavior"
+    description: "Describe what is currently happening, highlighting the differences between current and expected behavior:" 
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Steps to Reproduce Issue
+    description: "Enter the steps to reproduce the error:"
+    placeholder: |
+      1. Go to ...
+      2. Click on ....
+      3. Scroll down to ....
+      4. See error
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Screenshots
+    description: If applicable, add screenshots to help explain your problem.
+- type: textarea
+  id: localEnv
+  attributes:
+    label: Local Environment
+    description: "Please complete the following information:"
+    value: |
+      - OS:
+      - Open JDK Java Version:
+      - Apache Maven Version:
+      - [REPO/SOFTWARE] Version:
+- type: checkboxes
+  id: selfhelp
+  attributes:
+    label: Self-Service
+    description: If you feel like you could contribute to this issue, please check the box below.
+    options:
+      - label: I would be willing to fix this issue
+

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,23 @@
+# Java CI with Maven
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'azul'
+        cache: maven
+    - name: Build with Maven
+      run: mvn clean install


### PR DESCRIPTION
Included in this update:
* Add issues config to disable blank issues
* Technical Issues template
* Non-technical Issues template

Ref: https://ikmdev.atlassian.net/browse/IAT-1825