### PR TITLE
Java 24 Updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,14 +16,14 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v2
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
         
   build-job:
     name: Build Job
     runs-on: ubuntu-24.04
     steps:          
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{github.ref_name}}
          

--- a/.github/workflows/post_build.yaml
+++ b/.github/workflows/post_build.yaml
@@ -27,7 +27,7 @@ jobs:
           
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{github.event.workflow_run.head_branch}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           token: ${{secrets.IKMDEVOPS_PAT_TOKEN}}
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Automation/Devops Team
 
 Required for running this:
 
-1. Download and install Open JDK Java 23 (Azul preferred)
-2. Download and install Apache Maven 3.9.9 or later
+1. Download and install Open JDK Java 24 (Azul preferred)
+2. Download and install Apache Maven 3.9.11 or later
 3. Download and install Git
 
 ## Building and Running

--- a/java-parent/pom.xml
+++ b/java-parent/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <!-- make sure to change the hard coded java version in the enforcer as well -->
 
-        <java.version>23</java.version>
+        <java.version>24</java.version>
 
         <!-- Default Lifecycle additions -->
         <maven.resources-plugin.version>3.2.0</maven.resources-plugin.version>
@@ -41,6 +41,7 @@
         <auto-service.version>1.0.1</auto-service.version>
 
         <!-- Style and Code Quality Check Plugins -->
+        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
         <checkstyle.version>10.23.1</checkstyle.version>
         <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
@@ -201,6 +202,42 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven.jar-plugin.version}</version>
                 </plugin>
+
+                <!-- Maven Dependency Plugin Fix (Start) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <ignoredNonTestScopedDependencies>
+                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
+                                </ignoredNonTestScopedDependencies>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                                <ignoredUsedUndeclaredDependencies>
+                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>${maven-dependency-analyzer.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven Dependency Plugin Fix (End) -->
+
             </plugins>
         </pluginManagement>
 
@@ -500,8 +537,7 @@
                         <configuration>
                             <failurePriority>1</failurePriority>
                             <failOnViolation>false</failOnViolation>
-                            <aggregate>true</aggregate>
-                             <targetJdk>20</targetJdk>
+                             <targetJdk>${java.version}</targetJdk>
                         </configuration>
                         <executions>
                             <execution>

--- a/java-parent/pom.xml
+++ b/java-parent/pom.xml
@@ -21,8 +21,6 @@
     <properties>
         <!-- make sure to change the hard coded java version in the enforcer as well -->
 
-        <java.version>24</java.version>
-
         <!-- Default Lifecycle additions -->
         <maven.resources-plugin.version>3.2.0</maven.resources-plugin.version>
         <maven.surefire-plugin.version>3.5.3</maven.surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Java and Maven versions -->
-        <java.version>23</java.version>
-        <maven.version>3.9.9</maven.version>
+        <java.version>24</java.version>
+        <maven.version>3.9.11</maven.version>
 
 
         <!-- Clean Lifecycle -->


### PR DESCRIPTION
- Updated the GH Actions to us newer released versions
    - build.yaml
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Added some properties
        - <java.version>24</java.version>
        - <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>

- Removed aggregate parameter from maven-pmd-plugin

- Added transitive dependency fix for maven-dependency-plugin

- Removed "--enable-preview" from codebase